### PR TITLE
Add Assembly Devotion start and end time fields to SILNAT form

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,6 +743,16 @@ select.form-control option {
                     <input type="text" id="silnat_localGov" name="silnat_b_local_gov_common" class="form-control" required>
                 </div>
             </div>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="silnat_assemblyDevotion_startTime">Assembly Devotion Start Time</label>
+                    <input type="time" id="silnat_assemblyDevotion_startTime" name="silnat_assemblyDevotion_startTime" class="form-control" step="900"> <!-- step="900" for 15-minute intervals -->
+                </div>
+                <div class="form-group">
+                    <label for="silnat_assemblyDevotion_endTime">Assembly Devotion End Time</label>
+                    <input type="time" id="silnat_assemblyDevotion_endTime" name="silnat_assemblyDevotion_endTime" class="form-control" step="900"> <!-- step="900" for 15-minute intervals -->
+                </div>
+            </div>
             <!-- End of Section B placeholder -->
 
             <div class="form-row">


### PR DESCRIPTION
This commit introduces two new time input fields, 'Assembly Devotion Start Time' and 'Assembly Devotion End Time', to the SILNAT survey form in index.html.

The fields are placed directly after the 'Local Government' field and use standard HTML5 time inputs with a 'step' attribute to suggest 15-minute intervals.