### PR TITLE
Add Section B header to SILNAT form

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,6 +721,7 @@ select.form-control option {
             </div>
 
             <!-- Placeholder for existing fields that will become Section B -->
+            <h4>Section B: School/Institution Data</h4>
             <div class="form-row">
                 <div class="form-group">
                     <label for="silnat_schoolName">Name of School/Institution *</label> <!-- This label was already updated -->


### PR DESCRIPTION
Added the text 'Section B: School/Institution Data' as an H4-tag immediately after the placeholder comment for Section B in the SILNAT survey form in index.html.

This improves the form structure by clearly identifying the start of Section B.