### PR TITLE
Feat: Add non-teaching staff count fields to SILNAT form

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,6 +793,24 @@ select.form-control option {
                     </div>
                 </div>
             </div>
+
+            <div class="form-group" style="margin-top: 20px;">
+                <label style="font-weight: bold; display: block; margin-bottom: 10px;">Number of Pupils in the School:</label>
+                <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
+                    <div class="form-group">
+                        <label for="silnat_pupils_male">Male</label>
+                        <input type="number" id="silnat_pupils_male" name="silnat_pupils_male" class="form-control" min="0" placeholder="Male">
+                    </div>
+                    <div class="form-group">
+                        <label for="silnat_pupils_female">Female</label>
+                        <input type="number" id="silnat_pupils_female" name="silnat_pupils_female" class="form-control" min="0" placeholder="Female">
+                    </div>
+                    <div class="form-group">
+                        <label for="silnat_pupils_total">Total</label>
+                        <input type="number" id="silnat_pupils_total" name="silnat_pupils_total" class="form-control" min="0" placeholder="Total" readonly style="background-color: #e9ecef !important; opacity: 0.7 !important;">
+                    </div>
+                </div>
+            </div>
             <!-- End of Section B placeholder -->
 
             <div class="form-row">
@@ -2357,6 +2375,17 @@ document.addEventListener('DOMContentLoaded', () => {
     if (femaleNonTeachingInput) {
         femaleNonTeachingInput.addEventListener('input', updateSilnatTotalNonTeachingStaff);
     }
+
+    // Event listeners for SILNAT pupil count auto-calculation
+    const malePupilsInput = document.getElementById('silnat_pupils_male');
+    const femalePupilsInput = document.getElementById('silnat_pupils_female');
+
+    if (malePupilsInput) {
+        malePupilsInput.addEventListener('input', updateSilnatTotalPupils);
+    }
+    if (femalePupilsInput) {
+        femalePupilsInput.addEventListener('input', updateSilnatTotalPupils);
+    }
 });
 
 // Function to update total teachers for SILNAT form
@@ -2384,6 +2413,20 @@ function updateSilnatTotalNonTeachingStaff() {
         const femaleCount = parseInt(femaleNonTeachingInput.value, 10) || 0;
 
         totalNonTeachingInput.value = maleCount + femaleCount;
+    }
+}
+
+// Function to update total pupils for SILNAT form
+function updateSilnatTotalPupils() {
+    const malePupilsInput = document.getElementById('silnat_pupils_male');
+    const femalePupilsInput = document.getElementById('silnat_pupils_female');
+    const totalPupilsInput = document.getElementById('silnat_pupils_total');
+
+    if (malePupilsInput && femalePupilsInput && totalPupilsInput) {
+        const maleCount = parseInt(malePupilsInput.value, 10) || 0;
+        const femaleCount = parseInt(femalePupilsInput.value, 10) || 0;
+
+        totalPupilsInput.value = maleCount + femaleCount;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -775,6 +775,24 @@ select.form-control option {
                     </div>
                 </div>
             </div>
+
+            <div class="form-group" style="margin-top: 20px;">
+                <label style="font-weight: bold; display: block; margin-bottom: 10px;">Number of Non-Teaching Staff in the School:</label>
+                <div class="form-row" style="grid-template-columns: 1fr 1fr 1fr; gap: 15px;">
+                    <div class="form-group">
+                        <label for="silnat_non_teaching_male">Male</label>
+                        <input type="number" id="silnat_non_teaching_male" name="silnat_non_teaching_male" class="form-control" min="0" placeholder="Male">
+                    </div>
+                    <div class="form-group">
+                        <label for="silnat_non_teaching_female">Female</label>
+                        <input type="number" id="silnat_non_teaching_female" name="silnat_non_teaching_female" class="form-control" min="0" placeholder="Female">
+                    </div>
+                    <div class="form-group">
+                        <label for="silnat_non_teaching_total">Total</label>
+                        <input type="number" id="silnat_non_teaching_total" name="silnat_non_teaching_total" class="form-control" min="0" placeholder="Total" readonly style="background-color: #e9ecef !important; opacity: 0.7 !important;">
+                    </div>
+                </div>
+            </div>
             <!-- End of Section B placeholder -->
 
             <div class="form-row">
@@ -2328,6 +2346,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     // Initialize total teachers count in case of pre-filled values (e.g. form edit)
     // updateSilnatTotalTeachers(); // Call if needed on form load/edit
+
+    // Event listeners for SILNAT non-teaching staff count auto-calculation
+    const maleNonTeachingInput = document.getElementById('silnat_non_teaching_male');
+    const femaleNonTeachingInput = document.getElementById('silnat_non_teaching_female');
+
+    if (maleNonTeachingInput) {
+        maleNonTeachingInput.addEventListener('input', updateSilnatTotalNonTeachingStaff);
+    }
+    if (femaleNonTeachingInput) {
+        femaleNonTeachingInput.addEventListener('input', updateSilnatTotalNonTeachingStaff);
+    }
 });
 
 // Function to update total teachers for SILNAT form
@@ -2341,6 +2370,20 @@ function updateSilnatTotalTeachers() {
         const femaleCount = parseInt(femaleTeachersInput.value, 10) || 0;
 
         totalTeachersInput.value = maleCount + femaleCount;
+    }
+}
+
+// Function to update total non-teaching staff for SILNAT form
+function updateSilnatTotalNonTeachingStaff() {
+    const maleNonTeachingInput = document.getElementById('silnat_non_teaching_male');
+    const femaleNonTeachingInput = document.getElementById('silnat_non_teaching_female');
+    const totalNonTeachingInput = document.getElementById('silnat_non_teaching_total');
+
+    if (maleNonTeachingInput && femaleNonTeachingInput && totalNonTeachingInput) {
+        const maleCount = parseInt(maleNonTeachingInput.value, 10) || 0;
+        const femaleCount = parseInt(femaleNonTeachingInput.value, 10) || 0;
+
+        totalNonTeachingInput.value = maleCount + femaleCount;
     }
 }
 


### PR DESCRIPTION
- Introduced a new section 'Number of Non-Teaching Staff in the School' below the teacher count section in the SILNAT survey.
- This section includes input fields for male, female, and a readonly, auto-calculated total for non-teaching staff.
- The layout mirrors the teacher count section, with male, female, and total fields displayed on a single line using a three-column grid.
- Implemented a new JavaScript function `updateSilnatTotalNonTeachingStaff` and attached event listeners for real-time auto-calculation of the total.