### PR TITLE
Feat: Add Teacher/Pupils Ratio input field to SILNAT form

### DIFF
--- a/index.html
+++ b/index.html
@@ -865,6 +865,14 @@ select.form-control option {
                     </div>
                 </div>
             </div>
+
+            <div class="form-group" style="margin-top: 20px;">
+                <label for="silnat_teacher_pupil_ratio">Teacher/Pupils Ratio:</label>
+                <div style="display: flex; align-items: center;">
+                    <input type="number" id="silnat_teacher_pupil_ratio" name="silnat_teacher_pupil_ratio" class="form-control" min="0" step="any" placeholder="Enter ratio value" style="flex-grow: 1;">
+                    <span style="margin-left: 8px; font-size: 1em; flex-shrink: 0;">%</span>
+                </div>
+            </div>
             <!-- End of Section B placeholder -->
 
             <div class="form-row">


### PR DESCRIPTION
- Added a new field 'Teacher/Pupils Ratio:' to Section B of the SILNAT survey form.
- The field consists of a number input box allowing for decimal values (percentage) and a '%' symbol displayed next to it for clarity.
- Used a flex container to ensure the input and '%' symbol are aligned on the same line.
- The new field is placed after the detailed pupil count sections.